### PR TITLE
Add transducer arity to find-first

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -5,8 +5,17 @@
 
 (defn find-first
   "Finds the first item in a collection that matches a predicate."
-  [pred coll]
-  (reduce (fn [_ x] (if (pred x) (reduced x))) nil coll))
+  ([pred]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result x]
+        (if (pred x)
+          (ensure-reduced (rf result x))
+          result)))))
+  ([pred coll]
+   (reduce (fn [_ x] (if (pred x) (reduced x))) nil coll)))
 
 (defn dissoc-in
   "Dissociate a value in a nested assocative structure, identified by a sequence

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -5,8 +5,12 @@
             [medley.core :as m]))
 
 (deftest test-find-first
-  (is (= (m/find-first even? [7 3 3 2 8]) 2))
-  (is (nil? (m/find-first even? [7 3 3 7 3]))))
+  (testing "sequences"
+    (is (= (m/find-first even? [7 3 3 2 8]) 2))
+    (is (nil? (m/find-first even? [7 3 3 7 3]))))
+  (testing "transducers"
+    (is (= (transduce (m/find-first even?) + 0 [7 3 3 2 8]) 2))
+    (is (= (transduce (m/find-first even?) + 0 [7 3 3 7 3]) 0))))
 
 (deftest test-dissoc-in
   (is (= (m/dissoc-in {:a {:b {:c 1 :d 2}}} [:a :b :c])


### PR DESCRIPTION
Maybe not _the_ most useful transducer ever, but it makes sense that `find-first` would have a transducer arity. I wanted it at the repl once, and had to check if it had one.