### PR TITLE
Add flavours of selfmap macros for concise zipmap

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -327,3 +327,47 @@
   []
   #?(:clj  (java.util.UUID/randomUUID)
      :cljs (cljs.core/random-uuid)))
+
+(defmacro selfmapk
+  "Self-maps a collection to a hash map of keywords identical
+   to the input variables or collection of variables"
+  ([coll-or-var]
+   (let [body (if (coll? coll-or-var) coll-or-var [coll-or-var])]
+     (let [ks [(map keyword body)]]
+       `(let [vs# ~body]
+          (zipmap '~@ks vs#)))))
+  ([v1 v2 & body]
+   `(selfmapk [~v1 ~v2 ~@body])))
+
+(defmacro selfmapq
+  "Self-maps a collection to a hash map of fully-qualified keywords
+   identical to the input variables or collection
+   of variables"
+  ([coll-or-var]
+   (let [body (if (coll? coll-or-var) coll-or-var [coll-or-var])]
+     (let [ks [(map #(keyword (str *ns*) (str %)) body)]]
+       `(let [vs# ~body]
+          (zipmap '~@ks vs#)))))
+  ([v1 v2 & body]
+   `(selfmapq [~v1 ~v2 ~@body])))
+
+(defmacro selfmaps
+  "Self-maps a collection to a hash map of strings identical
+   to the input variables or collection of variables"
+  ([coll-or-var]
+   (let [body (if (coll? coll-or-var) coll-or-var [coll-or-var])]
+     (let [ks [(map name body)]]
+       `(let [vs# ~body]
+          (zipmap '~@ks vs#)))))
+  ([v1 v2 & body]
+   `(selfmaps [~v1 ~v2 ~@body])))
+
+(defmacro selfmapb
+  "Self-maps a collection to a hash map of symbols identical
+   to that of the input variables or collection of variables"
+  ([coll-or-var]
+   (let [body (if (coll? coll-or-var) coll-or-var [coll-or-var])]
+     `(let [vs# [~@body]]
+        (zipmap '~body vs#))))
+  ([v1 v2 & body]
+   `(selfmapb [~v1 ~v2 ~@body])))

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -273,3 +273,38 @@
     (is (instance? #?(:clj java.util.UUID :cljs cljs.core.UUID) x))
     (is (instance? #?(:clj java.util.UUID :cljs cljs.core.UUID) y))
     (is (not= x y))))
+
+(deftest test-selfmap-all-variants
+  (let [a 1 b 2 c 3]
+
+    (testing "selfmapk"
+      (is (= (m/selfmapk a) {:a a}))
+      (is (= (m/selfmapk a b) {:a a :b b}))
+      (is (= (m/selfmapk a b c) {:a a :b b :c c}))
+      (is (= (m/selfmapk [a]) {:a a}))
+      (is (= (m/selfmapk [a b]) {:a a :b b}))
+      (is (= (m/selfmapk [a b c]) {:a a :b b :c c})))
+
+    (testing "selfmapq"
+      (is (= (m/selfmapq a) {:medley.core-test/a a}))
+      (is (= (m/selfmapq a b) {:medley.core-test/a a :medley.core-test/b b}))
+      (is (= (m/selfmapq a b c) {:medley.core-test/a a :medley.core-test/b b :medley.core-test/c c}))
+      (is (= (m/selfmapq [a]) {:medley.core-test/a a}))
+      (is (= (m/selfmapq [a b]) {:medley.core-test/a a :medley.core-test/b b}))
+      (is (= (m/selfmapq [a b c]) {:medley.core-test/a a :medley.core-test/b b :medley.core-test/c c})))
+
+    (testing "selfmaps"
+      (is (= (m/selfmaps a) {"a" a}))
+      (is (= (m/selfmaps a b) {"a" a "b" b}))
+      (is (= (m/selfmaps a b c) {"a" a "b" b "c" c}))
+      (is (= (m/selfmaps [a]) {"a" a}))
+      (is (= (m/selfmaps [a b]) {"a" a "b" b}))
+      (is (= (m/selfmaps [a b c]) {"a" a "b" b "c" c})))
+
+    (testing "selfmapb"
+      (is (= (m/selfmapb a) {'a a}))
+      (is (= (m/selfmapb a b) {'a a 'b b}))
+      (is (= (m/selfmapb a b c) {'a a 'b b 'c c}))
+      (is (= (m/selfmapb [a]) {'a a}))
+      (is (= (m/selfmapb [a b]) {'a a 'b b}))
+      (is (= (m/selfmapb [a b c]) {'a a 'b b 'c c})))))


### PR DESCRIPTION
A repetitive patter I have come across is this

```clojure
(zipmap [:a :b :c] [a b c])
```

which is needed to build a map as an input to a map destructuring function (or build the map manually). The bindings are very often named identically to the input map's keys.

This set of functions remove the redundancy of having to reapeat the binding symbol as a keyword and reduces the boilerplate.

Several flavours provided: the map's key types can be plain key, qualified key, string and symbol.