### PR TITLE
Modify dissoc-in to accept variable args

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -21,15 +21,19 @@
   "Dissociate a value in a nested assocative structure, identified by a sequence
   of keys. Any collections left empty by the operation will be dissociated from
   their containing structures."
-  [m ks]
-  (if-let [[k & ks] (seq ks)]
-    (if (seq ks)
-      (let [v (dissoc-in (get m k) ks)]
-        (if (empty? v)
-          (dissoc m k)
-          (assoc m k v)))
-      (dissoc m k))
-    m))
+  ([m ks]
+   (if-let [[k & ks] (seq ks)]
+     (if (seq ks)
+       (let [v (dissoc-in (get m k) ks)]
+         (if (empty? v)
+           (dissoc m k)
+           (assoc m k v)))
+       (dissoc m k))
+     m))
+  ([m ks & kss]
+   (if-let [[ks' & kss] (seq kss)]
+     (recur (dissoc-in m ks) ks' kss)
+     (dissoc-in m ks))))
 
 (defn assoc-some
   "Associates a key with a value in a map, if and only if the value is not nil."

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -19,6 +19,8 @@
          {}))
   (is (= (m/dissoc-in {:a {:b {:c 1} :d 2}} [:a :b :c])
          {:a {:d 2}}))
+  (is (= (m/dissoc-in {:a {:b {:c 1} :d 2} :b {:c {:d 2 :e 3}}} [:a :b :c] [:b :c :d])
+         {:a {:d 2} :b {:c {:e 3}}}))
   (is (= (m/dissoc-in {:a 1} [])
          {:a 1})))
 


### PR DESCRIPTION
This pr solves issue #23 
Through this change we can use the dissoc-in function like in the following example
```clojure
(medley.core/dissoc-in {:a {:b 3 :c 4 :d 5}} [:a :b] [:a :c])
```