### PR TITLE
Allow records as param in mapping coll functions

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -45,9 +45,10 @@
      :cljs (satisfies? cljs.core.IEditableCollection coll)))
 
 (defn- reduce-map [f coll]
-  (if (editable? coll)
-    (persistent! (reduce-kv (f assoc!) (transient (empty coll)) coll))
-    (reduce-kv (f assoc) (empty coll) coll)))
+  (let [coll' (if (record? coll) (into {} coll) coll)]
+    (if (editable? coll')
+     (persistent! (reduce-kv (f assoc!) (transient (empty coll')) coll'))
+     (reduce-kv (f assoc) (empty coll') coll'))))
 
 (defn map-entry
   "Create a map entry for a key and value pair."

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -41,19 +41,28 @@
   (is (= (m/map-kv (fn [k v] [(name k) (inc v)]) (sorted-map :a 1 :b 2))
          {"a" 2 "b" 3}))
   (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) {:a 1 :b 2})
-         {"a" 2 "b" 3})))
+         {"a" 2 "b" 3}))
+  (testing "map-kv with record"
+    (defrecord MyRecord [x])
+    (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) (->MyRecord 1)) {"x" 2}))))
 
 (deftest test-map-keys
   (is (= (m/map-keys name {:a 1 :b 2})
          {"a" 1 "b" 2}))
   (is (= (m/map-keys name (sorted-map :a 1 :b 2))
-         (sorted-map "a" 1 "b" 2))))
+         (sorted-map "a" 1 "b" 2)))
+  (testing "map-keys with record"
+    (defrecord MyRecord [x])
+    (is (= (m/map-keys name (->MyRecord 1)) {"x" 1}))))
 
 (deftest test-map-vals
   (is (= (m/map-vals inc {:a 1 :b 2})
          {:a 2 :b 3}))
   (is (= (m/map-vals inc (sorted-map :a 1 :b 2))
-         (sorted-map :a 2 :b 3))))
+         (sorted-map :a 2 :b 3)))
+  (testing "map-vals with record"
+    (defrecord MyRecord [x])
+    (is (= (m/map-vals inc (->MyRecord 1)) {:x 2}))))
 
 (deftest test-filter-kv
   (is (= (m/filter-kv (fn [k v] (and (keyword? k) (number? v))) {"a" 1 :b 2 :c "d"})


### PR DESCRIPTION
Solves the issue #24 `map-vals, map-keys & map-kv raise an exception when called on a record`

I was thinking about convert the result again into a record but it has no sense if we modify the keys of the object, so at the end I have prefered return the result as a simple map