### PR TITLE
Add transducer arity to functions operating on maps 

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -80,54 +80,90 @@
   "Maps a function over the key/value pairs of an associate collection. Expects
   a function that takes two arguments, the key and value, and returns the new
   key and value as a collection of two elements."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v] (let [[k v] (f k v)] (xf m k v)))) coll))
+  ([f]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (rf result (f k v))))))
+  ([f coll]
+   (reduce-map (fn [xf] (fn [m k v] (let [[k v] (f k v)] (xf m k v)))) coll)))
 
 (defn map-keys
   "Maps a function over the keys of an associative collection."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v] (xf m (f k) v))) coll))
+  ([f]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (rf result [(f k) v])))))
+  ([f coll]
+   (reduce-map (fn [xf] (fn [m k v] (xf m (f k) v))) coll)))
 
 (defn map-vals
   "Maps a function over the values of an associative collection."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll))
+  ([f]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (rf result [k (f v)])))))
+  ([f coll]
+   (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll)))
 
 (defn filter-kv
   "Returns a new associative collection of the items in coll for which
   `(pred (key item) (val item))` returns true."
-  [pred coll]
-  (reduce-map (fn [xf] (fn [m k v] (if (pred k v) (xf m k v) m))) coll))
+  ([pred]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (if (pred k v) (rf result [k v]) result)))))
+  ([pred coll]
+   (reduce-map (fn [xf] (fn [m k v] (if (pred k v) (xf m k v) m))) coll)))
 
 (defn filter-keys
   "Returns a new associative collection of the items in coll for which
   `(pred (key item))` returns true."
-  [pred coll]
-  (reduce-map (fn [xf] (fn [m k v] (if (pred k) (xf m k v) m))) coll))
+  ([pred]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (if (pred k) (rf result [k v]) result)))))
+  ([pred coll]
+   (reduce-map (fn [xf] (fn [m k v] (if (pred k) (xf m k v) m))) coll)))
 
 (defn filter-vals
   "Returns a new associative collection of the items in coll for which
   `(pred (val item))` returns true."
-  [pred coll]
-  (reduce-map (fn [xf] (fn [m k v] (if (pred v) (xf m k v) m))) coll))
+  ([pred]
+   (fn [rf]
+     (fn
+       ([] (rf))
+       ([result] (rf result))
+       ([result [k v]] (if (pred v) (rf result [k v]) result)))))
+  ([pred coll]
+   (reduce-map (fn [xf] (fn [m k v] (if (pred v) (xf m k v) m))) coll)))
 
 (defn remove-kv
   "Returns a new associative collection of the items in coll for which
   `(pred (key item) (val item))` returns false."
-  [pred coll]
-  (filter-kv (complement pred) coll))
+  ([pred] (filter-kv (complement pred)))
+  ([pred coll] (filter-kv (complement pred) coll)))
 
 (defn remove-keys
   "Returns a new associative collection of the items in coll for which
   `(pred (key item))` returns false."
-  [pred coll]
-  (filter-keys (complement pred) coll))
+  ([pred] (filter-keys (complement pred)))
+  ([pred coll] (filter-keys (complement pred) coll)))
 
 (defn remove-vals
   "Returns a new associative collection of the items in coll for which
   `(pred (val item))` returns false."
-  [pred coll]
-  (filter-vals (complement pred) coll))
+  ([pred] (filter-vals (complement pred)))
+  ([pred coll] (filter-vals (complement pred) coll)))
 
 (defn queue
   "Creates an empty persistent queue, or one populated with a collection."

--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -96,14 +96,14 @@
 (defn map-keys
   "Maps a function over the keys of an associative collection."
   ([f]
-   (completing-rf (fn [rf result [k v]] (rf result [(f k) v]))))
+   (completing-rf (fn [rf result [k v]] (rf result (map-entry (f k) v)))))
   ([f coll]
    (reduce-map (fn [xf] (fn [m k v] (xf m (f k) v))) coll)))
 
 (defn map-vals
   "Maps a function over the values of an associative collection."
   ([f]
-   (completing-rf (fn [rf result [k v]] (rf result [k (f v)]))))
+   (completing-rf (fn [rf result [k v]] (rf result (map-entry k (f v))))))
   ([f coll]
    (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll)))
 
@@ -111,7 +111,7 @@
   "Returns a new associative collection of the items in coll for which
   `(pred (key item) (val item))` returns true."
   ([pred]
-   (completing-rf (fn [rf result [k v]] (if (pred k v) (rf result [k v]) result))))
+   (completing-rf (fn [rf result [k v]] (if (pred k v) (rf result (map-entry k v)) result))))
   ([pred coll]
    (reduce-map (fn [xf] (fn [m k v] (if (pred k v) (xf m k v) m))) coll)))
 
@@ -119,7 +119,7 @@
   "Returns a new associative collection of the items in coll for which
   `(pred (key item))` returns true."
   ([pred]
-   (completing-rf (fn [rf result [k v]] (if (pred k) (rf result [k v]) result))))
+   (completing-rf (fn [rf result [k v]] (if (pred k) (rf result (map-entry k v)) result))))
   ([pred coll]
    (reduce-map (fn [xf] (fn [m k v] (if (pred k) (xf m k v) m))) coll)))
 
@@ -127,7 +127,7 @@
   "Returns a new associative collection of the items in coll for which
   `(pred (val item))` returns true."
   ([pred]
-   (completing-rf (fn [rf result [k v]] (if (pred v) (rf result [k v]) result))))
+   (completing-rf (fn [rf result [k v]] (if (pred v) (rf result (map-entry k v)) result))))
   ([pred coll]
    (reduce-map (fn [xf] (fn [m k v] (if (pred v) (xf m k v) m))) coll)))
 

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -47,66 +47,118 @@
 (defrecord MyRecord [x])
 
 (deftest test-map-kv
-  (is (= (m/map-kv (fn [k v] [(name k) (inc v)]) {:a 1 :b 2})
-         {"a" 2 "b" 3}))
-  (is (= (m/map-kv (fn [k v] [(name k) (inc v)]) (sorted-map :a 1 :b 2))
-         {"a" 2 "b" 3}))
-  (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) {:a 1 :b 2})
-         {"a" 2 "b" 3}))
+  (testing "maps"
+    (is (= (m/map-kv (fn [k v] [(name k) (inc v)]) {:a 1 :b 2})
+           {"a" 2 "b" 3}))
+    (is (= (m/map-kv (fn [k v] [(name k) (inc v)]) (sorted-map :a 1 :b 2))
+           {"a" 2 "b" 3}))
+    (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) {:a 1 :b 2})
+           {"a" 2 "b" 3})))
   (testing "map-kv with record"
-    (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) (->MyRecord 1)) {"x" 2}))))
+    (is (= (m/map-kv (fn [k v] (m/map-entry (name k) (inc v))) (->MyRecord 1)) {"x" 2})))
+  (testing "transducers"
+    (is (= (into {} (m/map-kv (fn [k v] [(str k) (inc v)])) {:a 1 :b 2})
+           {":a" 2 ":b" 3}))))
 
 (deftest test-map-keys
-  (is (= (m/map-keys name {:a 1 :b 2})
-         {"a" 1 "b" 2}))
-  (is (= (m/map-keys name (sorted-map :a 1 :b 2))
-         (sorted-map "a" 1 "b" 2)))
+  (testing "maps"
+    (is (= (m/map-keys name {:a 1 :b 2})
+           {"a" 1 "b" 2}))
+    (is (= (m/map-keys name (sorted-map :a 1 :b 2))
+           (sorted-map "a" 1 "b" 2))))
   (testing "map-keys with record"
-    (is (= (m/map-keys name (->MyRecord 1)) {"x" 1}))))
+    (is (= (m/map-keys name (->MyRecord 1)) {"x" 1})))
+  (testing "transducers"
+    (is (= (into {} (m/map-keys name) {:a 1 :b 2})
+           {"a" 1 "b" 2}))
+    (is (= (into {} (m/map-keys name) (sorted-map :a 1 :b 2))
+           (sorted-map "a" 1 "b" 2)))))
 
 (deftest test-map-vals
-  (is (= (m/map-vals inc {:a 1 :b 2})
-         {:a 2 :b 3}))
-  (is (= (m/map-vals inc (sorted-map :a 1 :b 2))
-         (sorted-map :a 2 :b 3)))
+  (testing "maps"
+    (is (= (m/map-vals inc {:a 1 :b 2})
+           {:a 2 :b 3}))
+    (is (= (m/map-vals inc (sorted-map :a 1 :b 2))
+           (sorted-map :a 2 :b 3))))
+  (testing "transducers"
+    (is (= (into {} (m/map-vals inc) {:a 1 :b 2})
+           {:a 2 :b 3}))
+    (is (= (m/map-vals inc (sorted-map :a 1 :b 2))
+           (sorted-map :a 2 :b 3))))
   (testing "map-vals with record"
     (is (= (m/map-vals inc (->MyRecord 1)) {:x 2}))))
 
 (deftest test-filter-kv
-  (is (= (m/filter-kv (fn [k v] (and (keyword? k) (number? v))) {"a" 1 :b 2 :c "d"})
-         {:b 2}))
-  (is (= (m/filter-kv (fn [k v] (= v 2)) (sorted-map "a" 1 "b" 2))
-         (sorted-map "b" 2))))
+  (testing "maps"
+    (is (= (m/filter-kv (fn [k v] (and (keyword? k) (number? v))) {"a" 1 :b 2 :c "d"})
+           {:b 2}))
+    (is (= (m/filter-kv (fn [k v] (= v 2)) (sorted-map "a" 1 "b" 2))
+           (sorted-map "b" 2))))
+  (testing "transducers"
+    (is (= (into {} (m/filter-kv (fn [k v] (and (keyword? k) (number? v))))
+                 {"a" 1 :b 2 :c "d"})
+           {:b 2}))
+    (is (= (into {} (m/filter-kv (fn [k v] (= v 2)))
+                 (sorted-map "a" 1 "b" 2))
+           (sorted-map "b" 2)))))
 
 (deftest test-filter-keys
-  (is (= (m/filter-keys keyword? {"a" 1 :b 2})
-         {:b 2}))
-  (is (= (m/filter-keys #(re-find #"^b" %) (sorted-map "a" 1 "b" 2))
-         (sorted-map "b" 2))))
+  (testing "maps"
+    (is (= (m/filter-keys keyword? {"a" 1 :b 2})
+           {:b 2}))
+    (is (= (m/filter-keys #(re-find #"^b" %) (sorted-map "a" 1 "b" 2))
+           (sorted-map "b" 2))))
+  (testing "transducers"
+    (is (= (into {} (m/filter-keys keyword?) {"a" 1 :b 2})
+           {:b 2}))
+    (is (= (into {} (m/filter-keys #(re-find #"^b" %)) (sorted-map "a" 1 "b" 2))
+           (sorted-map "b" 2)))))
 
 (deftest test-filter-vals
-  (is (= (m/filter-vals even? {:a 1 :b 2})
-         {:b 2}))
-  (is (= (m/filter-vals even? (sorted-map :a 1 :b 2))
-         (sorted-map :b 2))))
+  (testing "maps"
+    (is (= (m/filter-vals even? {:a 1 :b 2})
+           {:b 2}))
+    (is (= (m/filter-vals even? (sorted-map :a 1 :b 2))
+           (sorted-map :b 2))))
+  (testing "transducers"
+    (is (= (into {} (m/filter-vals even?) {:a 1 :b 2})
+           {:b 2}))
+    (is (= (into {} (m/filter-vals even?) (sorted-map :a 1 :b 2))
+           (sorted-map :b 2)))))
 
 (deftest test-remove-kv
-  (is (= (m/remove-kv (fn [k v] (and (keyword? k) (number? v))) {"a" 1 :b 2 :c "d"})
-         {"a" 1 :c "d"}))
-  (is (= (m/remove-kv (fn [k v] (= v 2)) (sorted-map "a" 1 "b" 2))
-         (sorted-map "a" 1))))
+  (testing "maps"
+    (is (= (m/remove-kv (fn [k v] (and (keyword? k) (number? v))) {"a" 1 :b 2 :c "d"})
+           {"a" 1 :c "d"}))
+    (is (= (m/remove-kv (fn [k v] (= v 2)) (sorted-map "a" 1 "b" 2))
+           (sorted-map "a" 1))))
+  (testing "transducers"
+    (is (= (into {} (m/remove-kv (fn [k v] (and (keyword? k) (number? v))))
+                 {"a" 1 :b 2 :c "d"})
+           {"a" 1 :c "d"}))
+    (is (= (into {} (m/remove-kv (fn [k v] (= v 2)))
+                 (sorted-map "a" 1 "b" 2))
+           (sorted-map "a" 1)))))
 
 (deftest test-remove-keys
-  (is (= (m/remove-keys keyword? {"a" 1 :b 2})
-         {"a" 1}))
-  (is (= (m/remove-keys #(re-find #"^b" %) (sorted-map "a" 1 "b" 2))
-         {"a" 1})))
+  (testing "maps"
+    (is (= (m/remove-keys keyword? {"a" 1 :b 2})
+           {"a" 1}))
+    (is (= (m/remove-keys #(re-find #"^b" %) (sorted-map "a" 1 "b" 2))
+           {"a" 1})))
+  (testing "transducers"
+    (is (= (into {} (m/remove-keys keyword?) {"a" 1 :b 2})
+           {"a" 1}))))
 
 (deftest test-remove-vals
-  (is (= (m/remove-vals even? {:a 1 :b 2})
-         {:a 1}))
-  (is (= (m/remove-keys #(re-find #"^b" %) (sorted-map "a" 1 "b" 2))
-         {"a" 1})))
+  (testing "maps"
+    (is (= (m/remove-vals even? {:a 1 :b 2})
+           {:a 1}))
+    (is (= (m/remove-vals even? (sorted-map :a 1 :b 2))
+           (sorted-map :a 1))))
+  (testing "transducers"
+    (is (= (into {} (m/remove-vals even?) {:a 1 :b 2})
+           {:a 1}))))
 
 (deftest test-queue
   (testing "empty"


### PR DESCRIPTION
See discussion in #12 

Add a 1-argument arity to the following functions, which returns a transducer
consuming and producing a sequence of [key value] map-entry pairs, and can be
used to construct a map using (into {} xform coll).
- map-kv
- map-keys
- map-vals
- filter-kv
- filter-keys
- filter-vals
- remove-kv
- remove-keys
- remove-vals
- ~~index-by~~

The second commit refactors out repeated code into a private `completing-rf` function, if needed this can be omitted or squashed into the previous one.