### PR TITLE
Add variadic function arity to map-vals

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -89,9 +89,20 @@
   (reduce-map (fn [xf] (fn [m k v] (xf m (f k) v))) coll))
 
 (defn map-vals
-  "Maps a function over the values of an associative collection."
-  [f coll]
-  (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll))
+  "Maps a function over the values of one or more associative collections.
+  The function should accept number-of-colls arguments. Any keys which are not
+  shared among all collections are ignored."
+  ([f coll]
+   (reduce-map (fn [xf] (fn [m k v] (xf m k (f v)))) coll))
+  ([f c1 & colls]
+   (reduce-map
+    (fn [xf]
+      (fn [m k v]
+        (if (every? #(contains? % k) colls)
+          (xf m k (apply f v (map #(get % k) colls)))
+          m)))
+    c1)))
+
 
 (defn map-kv-keys
   "Maps a function over the key/value pairs of an associative collection, using

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -70,7 +70,20 @@
   (is (= (m/map-vals inc (sorted-map :a 1 :b 2))
          (sorted-map :a 2 :b 3)))
   (testing "map-vals with record"
-    (is (= (m/map-vals inc (->MyRecord 1)) {:x 2}))))
+    (is (= (m/map-vals inc (->MyRecord 1)) {:x 2})))
+  (testing "multiple collections"
+    (is (= (m/map-vals + {:a 1 :b 2 :c 3} {:a 4 :c 5 :d 6})
+           {:a 5, :c 8}))
+    (is (= (m/map-vals min
+                       (sorted-map :z 10 :y 8 :x 4)
+                       {:x 7, :y 14, :z 13}
+                       {:x 11, :y 6, :z 9}
+                       {:x 19, :y 3, :z 2}
+                       {:x 4, :y 0, :z 16}
+                       {:x 17, :y 14, :z 13})
+           (sorted-map :x 4 :y 0 :z 2)))
+    (is (= (m/map-vals #(%1 %2) {:a nil? :b some?} {:b nil})
+           {:b false}))))
 
 (deftest test-map-kv-keys
   (is (= (m/map-kv-keys + {1 2, 2 4})


### PR DESCRIPTION
Closes #35 

Mapping over collections with missing keys behaves as suggested in previous discussion - any keys which are not present in all collections will be omitted in the result. 

The type of the result collection depends on the first collection arg, on which `(empty)` is called.