### PR TITLE
Changes in deep-merge fn

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -216,14 +216,12 @@
   overwritten, as in `clojure.core/merge`."
   {:arglists '([& maps])
    :added    "1.1.0"}
-  ([])
-  ([a] a)
-  ([a b]
-   (if (and (map? a) (map? b))
-     (merge-with deep-merge a b)
-     b))
-  ([a b & more]
-   (apply merge-with deep-merge a b more)))
+  ([& maps]
+   (apply merge-with (fn [& args]
+                       (if (every? map? args)
+                         (apply deep-merge args)
+                         (last args)))
+          maps)))
 
 (defn mapply
   "Applies a function f to the argument list formed by concatenating

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -201,6 +201,7 @@
 (deftest test-deep-merge
   (is (= (m/deep-merge) nil))
   (is (= (m/deep-merge {:a 1}) {:a 1}))
+  (is (= (m/deep-merge {:a 1} nil) {:a 1}))
   (is (= (m/deep-merge {:a 1} {:a 2 :b 3}) {:a 2 :b 3}))
   (is (= (m/deep-merge {:a {:b 1 :c 2}} {:a {:b 2 :d 3}}) {:a {:b 2 :c 2 :d 3}}))
   (is (= (m/deep-merge {:a {:b 1}} {:a 1}) {:a 1}))


### PR DESCRIPTION
Proposal of changes to avoid behaviour
```
user=> (deep-merge {:a 1} nil)
nil
```
and make it like
```
user=> (merge {:a 1} nil)
{:a 1}
```

Code take from discussion https://gist.github.com/danielpcox/c70a8aa2c36766200a95