### PR TITLE
Add deps.edn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/.cpcache

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.clojure/clojure {:mvn/version "1.9.0"}}}


### PR DESCRIPTION
While not strictly necessary, adding a deps.edn to your project will make it easier to use medley as a git dep using tools.deps.