### PR TITLE
Remove the use of 'the' in assoc-some docstring

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -37,7 +37,7 @@
      (dissoc-in m ks))))
 
 (defn assoc-some
-  "Associates a key with a value in a map, if and only if the value is not nil."
+  "Associates a key k, with a value v in a map m, if and only if v is not nil."
   ([m k v]
    (if (nil? v) m (assoc m k v)))
   ([m k v & kvs]


### PR DESCRIPTION
Apologies James, I chose to edit my commit and do a force push to my fork, in an attempt to preserve the original pull request's discussion. It was unaware that this automatically closes the pull request, lesson learnt. 

Hope this isn't an issue, thanks for taking the time to review this.

Link to the original PR: https://github.com/weavejester/medley/pull/48