### PR TITLE
Add the nil-or-empty? function

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -507,3 +507,14 @@
   "Returns true if the value is a regular expression."
   [x]
   (instance? #?(:clj java.util.regex.Pattern :cljs js/RegExp) x))
+
+(defn nil-or-empty?
+  "An updated version of the clojure.core/empty? function that does not fail
+  when the input is not a collection."
+  [v]
+  (if (nil? v)
+    true
+    (cond
+      (coll? v) (empty? v)
+      (string? v) (clojure.string/blank? v)
+      :else false)))

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -405,3 +405,24 @@
   (is (m/regexp? #"x"))
   (is (not (m/regexp? "x")))
   (is (not (m/regexp? nil))))
+
+(deftest nil-or-empty?-test
+  (testing "nil-or-empty? given empty input should return true"
+    (is (true? (m/nil-or-empty? nil)))
+    (is (true? (m/nil-or-empty? "")))
+    (is (true? (m/nil-or-empty? "           ")))
+    (is (true? (m/nil-or-empty? '())))
+    (is (true? (m/nil-or-empty? [])))
+    (is (true? (m/nil-or-empty? {})))
+    (is (true? (m/nil-or-empty? #{})))
+    (is (true? (m/nil-or-empty? (hash-map)))))
+
+  (testing "nil-or-empty? given non empty input should return false"
+    (is (false? (m/nil-or-empty? 1)))
+    (is (false? (m/nil-or-empty? #?(:clj (Object.) :cljs (js-obj)))))
+    (is (false? (m/nil-or-empty? "ss")))
+    (is (false? (m/nil-or-empty? "    ss        ")))
+    (is (false? (m/nil-or-empty? '(1))))
+    (is (false? (m/nil-or-empty? [:a :b])))
+    (is (false? (m/nil-or-empty? {:a 1, :b 2})))
+    (is (false? (m/nil-or-empty? #{"s" "c" "ab"})))))


### PR DESCRIPTION
I often find myself re-implementing the function that I just added in this PR, in my projects, so I thought others might benefit from it.
A common use case is: needing to cleanup some hashmap's values, e.g.
```
(m/remove-vals empty? {:b nil
                       :c []
                       :d [1]
                       :e ""
                       :f "something"})
=> {:d [1], :f "something"}
```
But, I always have to remember to check for numbers in my collections, because, obviously:
```
(empty? 1)
=>IllegalArgumentException Don't know how to create ISeq from: java.lang.Long
```

What I'd like to be able to do is:
```
(m/remove-vals m/nil-or-empty? {:a 1
                                :b nil
                                :c []
                                :d [1]
                                :e ""
                                :f "something"})
=> {:a 1, :d [1], :f "something"}
```

Last but not least, I'm not that thrilled about the name for the function: `nil-or-empty?`, but `empty?` has been taken already...

Let me know what you think.