### PR TITLE
Add ^:assoc meta tag

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -213,7 +213,8 @@
 (defn deep-merge
   "Recursively merges maps together. If all the maps supplied have nested maps
   under the same keys, these nested maps are merged. Otherwise the value is
-  overwritten, as in `clojure.core/merge`."
+  overwritten, as in `clojure.core/merge`. With ^:assoc meta tag,
+  you can set a new value for an attribute."
   {:arglists '([& maps])
    :added    "1.1.0"}
   ([])
@@ -225,9 +226,10 @@
                      v' (val e)]
                  (if (contains? m k)
                    (assoc m k (let [v (get m k)]
-                                (if (and (map? v) (map? v'))
-                                  (deep-merge v v')
-                                  v')))
+                                (cond
+                                  (and (map? v) (map? v') (:assoc (meta v'))) v'
+                                  (and (map? v) (map? v')) (deep-merge v v')
+                                  :else v')))
                    (assoc m k v'))))]
        (reduce merge-entry (or a {}) (seq b)))))
   ([a b & more]

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -208,6 +208,7 @@
   (is (= (m/deep-merge {:a 1} {:b 2} {:b 3 :c 4}) {:a 1 :b 3 :c 4}))
   (is (= (m/deep-merge {:a {:b {:c {:d 1}}}} {:a {:b {:c {:e 2}}}}) {:a {:b {:c {:d 1 :e 2}}}}))
   (is (= (m/deep-merge {:a {:b [1 2]}} {:a {:b [3 4]}}) {:a {:b [3 4]}}))
+  (is (= (m/deep-merge {:a {:b [1 2]}} {:a {:b ^:assoc {}}}) {:a {:b {}}}))
   (is (= (m/deep-merge (->MyRecord 1) {:x 2}) (->MyRecord 2)))
   (is (= (m/deep-merge {:a (->MyRecord 1)} {:a {:x 2 :y 3}}) {:a (map->MyRecord {:x 2 :y 3})})))
 


### PR DESCRIPTION
Sometimes we'd like to set a value with the empty hash map but it does not work due to merge logic.

Current: 
```clojure
(deep-merge {:a {:b {:value 10}}} {:a {:b {}}}) -> {:a {:b {:value 10}}}
```

With **^:assoc** meta tag: 
```clojure
(deep-merge {:a {:b {:value 10}}} {:a {:b ^:assoc {}}}) -> {:a {:b {}}}
```