### PR TITLE
Exclude abs to fix Clojure 1.11 warnings

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -1,7 +1,8 @@
 (ns medley.core
   "A small collection of useful, mostly pure functions that might not look out
   of place in the clojure.core namespace."
-  (:refer-clojure :exclude [boolean? ex-cause ex-message uuid uuid? random-uuid regexp?]))
+  (:refer-clojure :exclude [abs boolean? ex-cause ex-message random-uuid regexp?
+                            uuid uuid?]))
 
 (defn find-first
   "Finds the first item in a collection that matches a predicate. Returns a


### PR DESCRIPTION
Fixes #59

* Added `abs` to the exclusion list
* Broke the line at 80 chars, also sorting excluded symbols in alpha order
* All tests pass
  ```
  Ran 44 tests containing 200 assertions.
  0 failures, 0 errors.
  ```