### PR TITLE
Add least-by & greatest-by fns

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -195,6 +195,26 @@
   ([a b] (if (neg? (compare a b)) a b))
   ([a b & more] (reduce least (least a b) more)))
 
+(defn least-by
+  "Return the argument for which (keyfn x) is least. Determined by the compare
+  function in O(n) time. Prefer `clojure.core/min-key` if keyfn returns numbers."
+  {:arglists '([keyfn & xs])
+   :added "1.6.0"}
+  ([_] nil)
+  ([_ x] x)
+  ([keyfn x y] (if (neg? (compare (keyfn x) (keyfn y))) x y))
+  ([keyfn x y & more]
+   (let [kx (keyfn x) ky (keyfn y)
+         [v kv] (if (neg? (compare kx ky)) [x kx] [y ky])]
+     (loop [v v kv kv more more]
+       (if more
+         (let [w (first more)
+               kw (keyfn w)]
+           (if (pos? (compare kw kv))
+             (recur v kv (next more))
+             (recur w kw (next more))))
+         v)))))
+
 (defn greatest
   "Find the greatest argument (as defined by the compare function) in O(n) time."
   {:arglists '([& xs])}
@@ -202,6 +222,26 @@
   ([a] a)
   ([a b] (if (pos? (compare a b)) a b))
   ([a b & more] (reduce greatest (greatest a b) more)))
+
+(defn greatest-by
+  "Return the argument for which (keyfn x) is greatest. Determined by the compare
+  function in O(n) time. Prefer `clojure.core/max-key` if keyfn returns numbers."
+  {:arglists '([keyfn & xs])
+   :added "1.6.0"}
+  ([_] nil)
+  ([_ x] x)
+  ([keyfn x y] (if (pos? (compare (keyfn x) (keyfn y))) x y))
+  ([keyfn x y & more]
+   (let [kx (keyfn x) ky (keyfn y)
+         [v kv] (if (pos? (compare kx ky)) [x kx] [y ky])]
+     (loop [v v kv kv more more]
+       (if more
+         (let [w (first more)
+               kw (keyfn w)]
+           (if (neg? (compare kw kv))
+             (recur v kv (next more))
+             (recur w kw (next more))))
+         v)))))
 
 (defn join
   "Lazily concatenates a collection of collections into a flat sequence."

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -182,11 +182,25 @@
   (is (= (m/least "a" "b") "a"))
   (is (= (m/least 3 2 5 -1 0 2) -1)))
 
+(deftest test-least-by
+  (is (= (m/least-by :a) nil))
+  (is (= (m/least-by :a {:a 42}) {:a 42}))
+  (is (= (m/least-by :a {:a 3} {:a 1} {:a 2}) {:a 1}))
+  (is (= (m/least-by :a {:a 3 :b 1} {:a 2 :b 2} {:a 2 :b 3}) {:a 2 :b 3}))
+  (is (= (m/least-by last "foo" "baa" "baz" "qux") "baa")))
+
 (deftest test-greatest
   (is (= (m/greatest) nil))
   (is (= (m/greatest "a") "a"))
   (is (= (m/greatest "a" "b") "b"))
   (is (= (m/greatest 3 2 5 -1 0 2) 5)))
+
+(deftest test-greatest-by
+  (is (= (m/greatest-by :a) nil))
+  (is (= (m/greatest-by :a {:a 42}) {:a 42}))
+  (is (= (m/greatest-by :a {:a 3} {:a 1} {:a 2}) {:a 3}))
+  (is (= (m/greatest-by :a {:a 2 :b 1} {:a 3 :b 2} {:a 3 :b 3}) {:a 3 :b 3}))
+  (is (= (m/greatest-by last "foo" "baa" "baz" "qux") "baz")))
 
 (deftest test-join
   (is (= (m/join [[1 2] []  [3] [4 5 6]]) [1 2 3 4 5 6]))


### PR DESCRIPTION
I've written these a few times over the years, and seen requests for them in clojurians slack too. They nicely complement `least` and `greatest` in the same way `sort-by` complements `sort`.
Edit: I had to rewrite it with a loop (like max-key and min-key) to avoid calling k too often.