### PR TITLE
Add the assoc-in-some function

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -51,6 +51,12 @@
        (recur (assoc-some-transient! m (first kvs) (second kvs)) (nnext kvs))
        (persistent! m)))))
 
+(defn assoc-in-some
+  "Associates a value v in a map m, following a nested structure defined by a
+  sequence of keys ks, if and only if v is not nil."
+  [m [k & ks] v]
+  (if (nil? v) m (assoc-in m (into [k] ks) v)))
+
 (defn update-existing
   "Updates a value in a map given a key and a function, if and only if the key
   exists in the map. See: `clojure.core/update`."

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -29,6 +29,14 @@
   (is (= (m/assoc-some {:a 1} :b nil) {:a 1}))
   (is (= (m/assoc-some {:a 1} :b 2 :c nil :d 3) {:a 1 :b 2 :d 3})))
 
+(deftest test-assoc-in-some
+  (is (= (m/assoc-in-some {} [] 1) {nil 1}))
+  (is (= (m/assoc-in-some {} [] nil) {}))
+  (is (= (m/assoc-in-some {:a 1} [:b] 2) {:a 1 :b 2}))
+  (is (= (m/assoc-in-some {:a 1} [:b] nil) {:a 1}))
+  (is (= (m/assoc-in-some {:a 1} [:b :c] 3) {:a 1 :b {:c 3}}))
+  (is (= (m/assoc-in-some {:a 1} [:b :c] nil) {:a 1})))
+
 (deftest test-update-existing
   (is (= (m/update-existing {:a 1} :a inc) {:a 2}))
   (is (= (m/update-existing {:a 1 :b 2} :a inc) {:a 2 :b 2}))


### PR DESCRIPTION
A function that behaves similarly to `assoc-some`, but for nested keys. Works based on `clojure.core/assoc-in`.