### PR TITLE
Add partition-between

### DIFF
--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -355,6 +355,29 @@
                       [1 3 5 6 8 9])
            [[1 3 5] [6]]))))
 
+(deftest test-partition-between
+  (testing "sequences"
+    (is (= (m/partition-between = nil) '()))
+    (is (= (m/partition-between < [1]) '((1))))
+    (is (= (m/partition-between < [1 1 2 2 1 1 3 3 3])
+           '((1 1) (2 2 1 1) (3 3 3))))
+    (is (= (m/partition-between < [1 2 3 4]) '((1) (2) (3) (4))))
+    (is (= (m/partition-between < [4 3 2 1]) '((4 3 2 1)))))
+
+  (testing "transducers"
+    (is (= (transduce (m/partition-between <) conj nil) []))
+    (is (= (transduce (m/partition-between <) conj [1]) [[1]]))
+    (is (= (transduce (m/partition-between <) conj [1 1 2 2 1 1 3 3 3])
+           [[1 1] [2 2 1 1] [3 3 3]]))
+    (is (= (sequence (m/partition-between <) [1 2 3 4]) '([1] [2] [3] [4])))
+    (is (= (into [] (m/partition-between <) [4 3 2 1]) [[4 3 2 1]]))
+    (is (= (transduce (m/partition-between <)
+                      (completing (fn [coll x]
+                                    (cond-> (conj coll x) (= [8] x) reduced)))
+                      []
+                      [1 2 3 2 8 9])
+           [[1] [2] [3 2] [8]]))))
+
 (deftest test-indexed
   (testing "sequences"
     (is (= (m/indexed [:a :b :c :d])


### PR DESCRIPTION
In, for example, [this Ask Clojure question](https://ask.clojure.org/index.php/9450/partitioning-list-based-comparing-the-elements-within-list) and [this Stackoverflow question](https://stackoverflow.com/questions/75628071/in-clojure-how-to-partition-an-array-of-sorted-integers-into-contiguous-partitio) there's asked for the partitioning of a sequence based on comparing consecutive values. `partition-when` implements this.

The implementation is based on Clojure's [`partition-by`](https://github.com/clojure/clojure/blob/clojure-1.11.1/src/clj/clojure/core.clj#L7228) and Medley's [`partition-after`](https://github.com/weavejester/medley/blob/285834aa1feec9e02cebea38b5dc83e2b7eea868/src/medley/core.cljc#L405) and [`partition-before`](https://github.com/weavejester/medley/blob/285834aa1feec9e02cebea38b5dc83e2b7eea868/src/medley/core.cljc#L437).

Note that also the non-transducer two-arity implementation is stateful to keep it performant and lazy.