### PR TITLE
Remove unnecessary lazy-seq call

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -440,12 +440,11 @@
                (when-let [[x & xs] (seq coll)]
                  (when-not (pred prev x)
                    (cons x (take-part x xs))))))]
-      (lazy-seq
-       (when-let [[x & xs] (seq coll)]
-         (let [run (take-part x xs)]
-           (cons (cons x run)
-                 (partition-between pred
-                                    (lazy-seq (drop (count run) xs)))))))))))
+      (when-let [[x & xs] (seq coll)]
+        (let [run (take-part x xs)]
+          (cons (cons x run)
+                (partition-between pred
+                                   (lazy-seq (drop (count run) xs))))))))))
 
 (defn partition-after
   "Returns a lazy sequence of partitions, splitting after `(pred item)` returns


### PR DESCRIPTION
Just noticed as I was checking the source code, that partition-between calls `lazy-seq` twice in a row (well, with a letfn binding form between them, but that doesn't matter), which is unnecessary. All tests still pass without it, as would be expected. Low priority, no doubt, but worth tidying up I guess.