### PR TITLE
Add mapcat-indexed function

### DIFF
--- a/src/medley/core.cljc
+++ b/src/medley/core.cljc
@@ -550,6 +550,21 @@
   ([coll]
    (map-indexed vector coll)))
 
+(defn mapcat-indexed
+  "Returns the result of applying concat to the result of applying f to 0 and
+  the first item of coll, followed by applying f to 1 and the second item in
+  coll, etc, until coll is exhausted. Thus function f should accept 2 arguments,
+  index and item. Returns a stateful transducer when no collection is provided."
+  ([f]
+   (comp (map-indexed f) cat))
+  ([f coll]
+   (letfn [(mapci [idx coll]
+             (lazy-seq
+              (when-let [s (seq coll)]
+                (concat (f idx (first s))
+                        (mapci (inc idx) (rest s))))))]
+     (mapci 0 coll))))
+
 (defn insert-nth
   "Returns a lazy sequence of the items in coll, with a new item inserted at
   the supplied index, followed by all subsequent items of the collection. Runs

--- a/test/medley/core_test.cljc
+++ b/test/medley/core_test.cljc
@@ -433,6 +433,27 @@
     (is (= (into [] (m/indexed) [])
            []))))
 
+(deftest test-mapcat-indexed
+  (testing "sequences"
+    (is (= (m/mapcat-indexed vector nil)
+           []))
+    (is (= (m/mapcat-indexed vector [])
+           []))
+    (is (= (m/mapcat-indexed repeat [:a :b :c :d])
+           [:b :c :c :d :d :d]))
+    (is (= (m/mapcat-indexed repeat [])
+           [])))
+
+  (testing "transducers"
+    (is (= (into [] (m/mapcat-indexed vector) nil)
+           []))
+    (is (= (into [] (m/mapcat-indexed vector) [])
+           []))
+    (is (= (into [] (m/mapcat-indexed repeat) [:a :b :c :d])
+           [:b :c :c :d :d :d]))
+    (is (= (into [] (m/mapcat-indexed repeat) [])
+           []))))
+
 (deftest test-insert-nth
   (testing "sequences"
     (is (= (m/insert-nth 0 :a [1 2 3 4]) [:a 1 2 3 4]))


### PR DESCRIPTION
I feel this fits with medley pretty well. It exists in Kotlin as [flatMapIndexed](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.collections/flat-map-indexed.html) which I've used a few times recently, and realised is missing from clojure.core. It also exists in JS as the dyadic form of [flatMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap). It's useful for conditionally inserting extra items based on index, among other things. e.g.

```clojure
(mapcat-indexed (fn [i x] (if (even? i) [x :break] [x]))
                '[a b c d e f g h i j h])
;; => (a :break b c :break d e :break f g :break h i :break j h :break)
```

lmk what you think :)